### PR TITLE
Added Deprecation warning and conftest, remove call dict from PredictMixin

### DIFF
--- a/btyd/__init__.py
+++ b/btyd/__init__.py
@@ -1,4 +1,5 @@
 """ All legacy lifetimes models from ./fitters/, and Bayesian models from ./models/. """
+import warnings
 
 from .fitters import BaseFitter
 from .fitters.beta_geo_fitter import BetaGeoFitter
@@ -22,4 +23,9 @@ __all__ = (
     "BetaGeoCovarsFitter",
     "BetaGeoModel"
     )
+
+def deprecated():
+   warnings.warn("All Fitter models are deprecated and will be removed in the final stage of Beta development.", DeprecationWarning)
+
+deprecated()
  

--- a/btyd/models/__init__.py
+++ b/btyd/models/__init__.py
@@ -20,6 +20,9 @@ SELF = TypeVar("SELF")
 
 class BaseModel(ABC, Generic[SELF]):
 
+    # This attribute must be defined in model subclasses.
+    _quantities_of_interest: dict
+
     @abstractmethod
     def __init__(self) -> SELF:
         """ self._param_list must be instantiated here, as well as model hyperpriors."""
@@ -246,10 +249,3 @@ class PredictMixin(ABC, Generic[SELF]):
         posterior_draws: int = 100
         ) -> None:
         pass
-    
-    _quantities_of_interest = {
-        'cond_prob_alive': _conditional_probability_alive,
-        'cond_n_prchs_to_time': _conditional_expected_number_of_purchases_up_to_time,
-        'n_prchs_to_time': _expected_number_of_purchases_up_to_time,
-        'prob_n_prchs_to_time': _probability_of_n_purchases_up_to_time,
-        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from btyd.datasets import load_cdnow_summary_data_with_monetary_value
+
+import pandas as pd
+
+
+@pytest.fixture(scope='module')
+def cdnow_customers() -> pd.DataFrame:
+    """ Create an RFM dataframe for multiple tests and fixtures. """
+    rfm_df = load_cdnow_summary_data_with_monetary_value()
+    return rfm_df

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -24,12 +24,23 @@ from btyd.datasets import (
     load_transaction_data,
 )
 
+def test_deprecated():
+    """
+    GIVEN the deprecated() function for DeprecationWarnings,
+    WHEN it is called,
+    THEN one warning of category DeprecationWarning containing `deprecated` in the message is returned.
+    """
+    
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Trigger a warning.
+        btyd.deprecated()
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)
 
-@pytest.fixture(scope='module')
-def cdnow_customers() -> pd.DataFrame:
-    """ Create an RFM dataframe for multiple tests and fixtures. """
-    rfm_df = load_cdnow_summary_data_with_monetary_value()
-    return rfm_df
 
 @pytest.mark.parametrize("obj",[btyd.BaseModel, btyd.PredictMixin])
 def test_isabstract(obj):
@@ -105,17 +116,6 @@ class TestBaseModel:
 
 
 class TestPredictMixin:
-    
-    def test_call_dict(self):
-        """
-        GIVEN the PredictMixin model factory object,
-        WHEN the keys of the 'quantities_of_interest' call dictionary attribute are returned,
-        THEN they should match the list of expected keys.
-        """
-
-        expected = ['cond_prob_alive', 'cond_n_prchs_to_time', 'n_prchs_to_time', 'prob_n_prchs_to_time']
-        actual = list(btyd.PredictMixin._quantities_of_interest.keys()) 
-        assert actual == expected
     
     def test_abstract_methods(self):
         """

--- a/tests/test_beta_geo_model.py
+++ b/tests/test_beta_geo_model.py
@@ -27,13 +27,6 @@ from btyd.datasets import (
 
 PATH_BGNBD_MODEL = "./bgnbd.json"
 
-# PUT THIS IN CONFTEST.PY
-@pytest.fixture(scope='module')
-def cdnow_customers() -> pd.DataFrame:
-    """ Create an RFM dataframe for multiple tests and fixtures. """
-    rfm_df = load_cdnow_summary_data_with_monetary_value()
-    return rfm_df
-
 
 class TestBetaGeoModel:
 
@@ -269,6 +262,17 @@ class TestBetaGeoModel:
         # assert prediction exception
 
         os.remove(PATH_BGNBD_MODEL)
+    
+    def test_quantities_of_interest(self):
+        """
+        GIVEN the _quantities_of_interest BaseModel attribute,
+        WHEN the keys of the '_quantities_of_interest' call dictionary attribute are called,
+        THEN they should match the list of expected keys.
+        """
+
+        expected = ['cond_prob_alive', 'cond_n_prchs_to_time', 'n_prchs_to_time', 'prob_n_prchs_to_time']
+        actual = list(btyd.BetaGeoModel._quantities_of_interest.keys()) 
+        assert actual == expected
     
     @pytest.mark.parametrize("qoi, instance",[("cond_prob_alive",np.ndarray),
                                             ("cond_n_prchs_to_time",np.float64), 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -21,11 +21,6 @@ PATH_SAVE_MODEL = "./base_fitter.pkl"
 PATH_SAVE_BGNBD_MODEL = "./betageo_fitter.pkl"
 
 
-@pytest.fixture
-def cdnow_customers():
-    return load_cdnow_summary()
-
-
 class TestBaseFitter:
     def test_repr(self):
         base_fitter = lt.BaseFitter()


### PR DESCRIPTION
Just incorporating a few best practices at the end of the Alpha development stage.

I've added a Deprecation warning reminding users [the legacy Lifetimes `fitters` module will be deprecated during Beta development](https://github.com/ColtAllen/lifetimes/discussions/18) and also moved the `cdnow_summary` pytest fixture to `conftest.py` so that it may be shared among all testing scripts.

Lastly, after scratching my head for a while over the DRY (Don't Repeat Yourself) development principle and Python object inheritance, I've opted to remove the `_quantities_of_interest` predictive method call dictionary from the `PredictMixin` abstract model primitive. It adds a small amount of code redundancy as this dict must now be defined in all model subclasses, but there will nonetheless be variations in the items this dict contains depending on the model. This is the most pythonic solution for this code smell and way more maintainable than alternatives involving complexities like  `super().predict()`.