### PR TITLE
Removed Model Persistence

### DIFF
--- a/btyd/models/__init__.py
+++ b/btyd/models/__init__.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 
 import pymc as pm
-import arviz as az
 import aesara.tensor as at
 
 from ..utils import _check_inputs
@@ -92,6 +91,13 @@ class BaseModel(ABC, Generic[SELF]):
     def _unload_params(self, posterior: bool = False, n_samples: int = 100) -> Union[Tuple[np.ndarray],Tuple[np.ndarray]]:
         """Extract parameter posteriors from _idata InferenceData attribute of fitted model."""
 
+        # BETA TODO: Raise BTYDException.
+         # if dict(filter(lambda item: self.__class__.__name__ not in item[0], self.idata.posterior.get('data_vars').items()))
+             # raise BTYDException
+        
+        # test param exception (need another saved model and additions to self._unload_params())
+        # test prediction exception if attempting to run predictions on instantiated model without RFM data.
+
         if posterior:
             return tuple(
                 [
@@ -138,42 +144,6 @@ class BaseModel(ABC, Generic[SELF]):
             pass
         
         return predictions
-        
-    def save_model(self, filename: str) -> None:
-        """
-        Dump InferenceData from fitted model into a JSON file.
-
-        Parameters
-        ----------
-        filename: str
-            Path and/or filename where model will be saved.
-
-        """
-        
-        self.idata.to_json(filename)
-
-    def load_model(self, filename: str) -> SELF:
-        """
-        Load saved model JSON.
-
-        Parameters
-        ----------
-        filename: str
-            Path and/or filename of model JSON.
-
-        Returns
-        -------
-        self
-            with loaded ``_idata`` attribute for model evaluation and predictions.
-        """
-
-        self.idata = az.from_json(filename)
-        
-        # BETA TODO: Raise BTYDException.
-        # if dict(filter(lambda item: self.__class__.__name__ not in item[0], self.idata.posterior.get('data_vars').items()))
-            # raise BTYDException
-
-        return self
     
     @staticmethod
     def _dataframe_parser(rfm_df: pd.DataFrame) -> Tuple[np.ndarray]:

--- a/tests/test_beta_geo_model.py
+++ b/tests/test_beta_geo_model.py
@@ -1,9 +1,6 @@
 from __future__ import generator_stop
 from __future__ import annotations
 
-import os
-from abc import ABC
-import warnings
 import inspect
 
 import pytest
@@ -23,9 +20,6 @@ from btyd.datasets import (
     load_donations,
     load_transaction_data,
 )
-
-
-PATH_BGNBD_MODEL = "./bgnbd.json"
 
 
 class TestBetaGeoModel:
@@ -232,36 +226,6 @@ class TestBetaGeoModel:
         )
         actual = np.array([fitted_bgm._probability_of_n_purchases_up_to_time(30, n) for n in range(11, 21)]).flatten()
         np.testing.assert_allclose(expected, actual,rtol=1e-02)
-    
-    def test_save_model(self, fitted_bgm):
-        """
-        GIVEN a fitted BetaGeoModel object,
-        WHEN self.save_model() is called,
-        THEN the external file should exist.
-        """
-
-        # os.remove(PATH_BGNBD_MODEL)
-        assert os.path.isfile(PATH_BGNBD_MODEL) == False
-        
-        fitted_bgm.save_model(PATH_BGNBD_MODEL)
-        assert os.path.isfile(PATH_BGNBD_MODEL) == True
-
-    def test_load_predict(self, fitted_bgm):
-        """
-        GIVEN fitted and unfitted BetaGeoModel objects,
-        WHEN parameters of the fitted model are loaded from an external JSON via self.load_model(),
-        THEN InferenceData unloaded parameters should match, raising exceptions otherwise and if predictions attempted without RFM data.
-        """
-
-        bgm_new = btyd.BetaGeoModel()
-        bgm_new.load_model(PATH_BGNBD_MODEL)
-        assert isinstance(bgm_new.idata,az.InferenceData)
-        assert bgm_new._unload_params() == fitted_bgm._unload_params()
-        
-        # assert param exception (need another saved model and additions to self.load_model())
-        # assert prediction exception
-
-        os.remove(PATH_BGNBD_MODEL)
     
     def test_quantities_of_interest(self):
         """


### PR DESCRIPTION
Removing the save_model() and load_model() methods to streamline the new modeling API is an act some of you may find controversial, but both methods are literally single-line wrappers for the equivalent functions in [ArViZ](https://arviz-devs.github.io/arviz/examples/index.html).

ArViZ is a very powerful library that is automatically installed along with BTYD because it is a transitive dependency of BTYD's core dependency, [PyMC](https://github.com/pymc-devs/pymc). There will be a future PR wrapping an aggregation of useful arviz model evaluation plots and metrics, but otherwise I don't want to see BTYD become a thin wrapper for what can be done by simply passing in Model.idata into ArViZ.

In the next PR I'll be adding instructions to the documentation on how to persist models in ArViz:

import btyd
import arviz as az

data_df = btyd.load_cdnow_summary()

bgm = btyd.BetaGeoModel().fit(data_df)

# Save inference data of a fitted model as a JSON:
bgm.idata.to_json('path/to/file.json')

# Load model inference data from a JSON:
bgm._idata = az.from_json('path/to/file.json')
Another advantage of scrapping persistence from the BTYD model API is that ArViZ supports a variety of file formats, so users are no longer restricted to JSON files for models. Once this project is in Beta I also want to add some model type checkers originally intended for load_model(), but those can be assumed by the BaseModel._unload_params() method instead.