### PR TITLE
Added readthedocs.yaml

### DIFF
--- a/docs/source/High Level Overview.md
+++ b/docs/source/High Level Overview.md
@@ -6,7 +6,7 @@ This is intended to be a high-level documentation of how the code is structured.
 
 The usual workflow of using the `btyd` library is exemplified in the [User Guide](User Guide.md) page. It can also be represented through the following fluxogram:
 
-![Basic Workflow](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/btyd_workflow.png)
+![Basic Workflow](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/btyd_workflow.png)
 
 Notice that the right-most branch of the fluxogram actually refers to *monetary value* modeling.
 
@@ -14,15 +14,15 @@ Notice that the right-most branch of the fluxogram actually refers to *monetary 
 
 The core model primitive is the `BaseModel` abstract class inside `__init__.py`, which serves as a *superclass* for all models in BTYD. So far, only the `BetaGeoModel` is set on a higher layer, inheriting from the `BaseModel` and `PredictMixin` abstract classes. `PredictMixin` enforces model prediction conventions for all models except `GammaGammaModel`. The following image shows the UML Class Diagram for all modeling objects:
 
-![models_uml](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/models_uml.png)
-If the image is too small, you can go to the source [here](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/models_uml.png).
+![models_uml](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/docs/source/_static/models_uml.png)
+If the image is too small, you can go to the source [here](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/models_uml.png).
 
 ## Graphs
 
 Graphs are plotted with functions coming from the `plotting.py` file. The main functions are cited below, alongside a brief description of how they are created:
 
-![plotting.py functions](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/btyd_plotting.png)
-If the image is too small, you can go to the source [here](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/btyd_plotting.png).
+![plotting.py functions](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/btyd_plotting.png)
+If the image is too small, you can go to the source [here](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/btyd_plotting.png).
 
 - `plot_period_transactions` : aggregation on how many purchases each customer has made in the calibration period.
 - `plot_calibration_purchases_vs_holdout_purchases` : aggregation over the conditional expected number of purchases.

--- a/docs/source/User Guide.md
+++ b/docs/source/User Guide.md
@@ -55,7 +55,7 @@ from btyd.plotting import plot_frequency_recency_matrix
 plot_frequency_recency_matrix(bgm)
 ```
 
-![rfm_matrix](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/rfmatrix.png)
+![rfm_matrix](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/rfmatrix.png)
 
 
 We can see that if a customer has bought 25 times from you, and their latest purchase was when they were 35 weeks old (given the individual is 35 weeks old), then they are your best customer (bottom-right). Your coldest customers are those that are in the top-right corner: they bought a lot quickly, and we haven't seen them in weeks.
@@ -70,7 +70,7 @@ from btyd.plotting import plot_probability_alive_matrix
 plot_probability_alive_matrix(bgm)
 ```
 
-![prob](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/alivematrix.png)
+![prob](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/alivematrix.png)
 
 ##### Ranking customers from best to worst
 
@@ -102,7 +102,7 @@ from btyd.plotting import plot_period_transactions
 plot_period_transactions(bgm)
 ```
 
-![model_fit_1](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/plotperiodtrans.png)
+![model_fit_1](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/plotperiodtrans.png)
 
 We can see that our actual data and our simulated data line up well.
 
@@ -174,7 +174,7 @@ bgm.fit(summary_cal_holdout)
 plot_calibration_purchases_vs_holdout_purchases(bgf, summary_cal_holdout)
 ```
 
-![holdout](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/holdout_graph.png)
+![holdout](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/holdout_graph.png)
 
 ##### Customer Predictions
 
@@ -202,7 +202,7 @@ sp_trans = transaction_data.loc[transaction_data['id'] == id]
 plot_history_alive(bgm, days_since_birth, sp_trans, 'date')
 ```
 
-![history](https://raw.githubusercontent.com/ColtAllen/btyd/docs/update_read_the_docs/docs/source/_static/palive_history.png)
+![history](https://raw.githubusercontent.com/ColtAllen/btyd/main/docs/source/_static/palive_history.png)
 
 ### Estimating Customer Lifetime Value using the Gamma-Gamma model
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: sphinxcontrib-napoleon myst-parser pydata-sphinx-theme


### PR DESCRIPTION
[A configuration file](https://docs.readthedocs.io/en/stable/config-file/v2.html) is required for any docs builds on ReadTheDocs.org requiring external `sphinx` plugins. Since ReadTheDocs only builds from the `main` branch, this could be the first in a series of PRs to get the online documentation to render properly.