### PR TITLE
Remove dependency on dill

### DIFF
--- a/btyd/fitters/__init__.py
+++ b/btyd/fitters/__init__.py
@@ -3,7 +3,7 @@
 import warnings
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
-import dill
+import pickle
 import numpy as np
 import pandas as pd
 from textwrap import dedent
@@ -36,7 +36,7 @@ class BaseFitter(object):
             raise ValueError("Model has not been fit yet. Please call the .fit" " method first.")
         return [self.params_[x] for x in args]
 
-    def save_model(self, path, save_data=True, save_generate_data_method=True, values_to_save=None):
+    def save_model(self, path, save_data=True, values_to_save=None):
         """
         Save model with dill package.
 
@@ -46,15 +46,12 @@ class BaseFitter(object):
             Path where to save model.
         save_data: bool, optional
             Whether to save data from fitter.data to pickle object
-        save_generate_data_method: bool, optional
-            Whether to save generate_new_data method (if it exists) from
-            fitter.generate_new_data to pickle object.
         values_to_save: list, optional
             Placeholders for original attributes for saving object. If None
             will be extended to attr_list length like [None] * len(attr_list)
 
         """
-        attr_list = ["data" * (not save_data), "generate_new_data" * (not save_generate_data_method)]
+        attr_list = ["data" * (not save_data), "generate_new_data"]
         _save_obj_without_attr(self, attr_list, path, values_to_save=values_to_save)
 
     def load_model(self, path):
@@ -68,7 +65,7 @@ class BaseFitter(object):
 
         """
         with open(path, "rb") as in_file:
-            self.__dict__.update(dill.load(in_file).__dict__)
+            self.__dict__.update(pickle.load(in_file).__dict__)
 
     def _compute_variance_matrix(self):
         params_ = self.params_

--- a/btyd/fitters/beta_geo_beta_binom_fitter.py
+++ b/btyd/fitters/beta_geo_beta_binom_fitter.py
@@ -164,17 +164,21 @@ class BetaGeoBetaBinomFitter(BaseFitter):
             {"frequency": frequency, "recency": recency, "n_periods": n_periods, "weights": weights}, index=index
         )
 
-        self.generate_new_data = lambda size=1: beta_geometric_beta_binom_model(
-            # Making a large array replicating n by n_custs having n.
-            np.array(sum([n_] * n_cust for (n_, n_cust) in zip(n_periods, weights))),
-            *self._unload_params("alpha", "beta", "gamma", "delta"),
-            size=size
-        )
+        self.generate_new_data_params = (n_periods, weights)
 
         self.variance_matrix_ = self._compute_variance_matrix()
         self.standard_errors_ = self._compute_standard_errors()
         self.confidence_intervals_ = self._compute_confidence_intervals()
         return self
+
+    def generate_new_data(self, size=1):
+        n_periods, weights = self.generate_new_data_params
+        return beta_geometric_beta_binom_model(
+            # Making a large array replicating n by n_custs having n.
+            np.array(sum([n_] * n_cust for (n_, n_cust) in zip(n_periods, weights))),
+            *self._unload_params("alpha", "beta", "gamma", "delta"),
+            size=size
+        )
 
     def conditional_expected_number_of_purchases_up_to_time(self, m_periods_in_future, frequency, recency, n_periods):
         r"""

--- a/btyd/fitters/beta_geo_covar_fitter.py
+++ b/btyd/fitters/beta_geo_covar_fitter.py
@@ -155,11 +155,15 @@ class BetaGeoCovarsFitter(BaseFitter):
         if index is not None:
             self.data.index = index
 
-        self.generate_new_data = lambda size=1: beta_geometric_nbd_model(
-            T, *self._unload_params('r', 'alpha0', 'a0', 'b0'), size=size)
+        self.generate_new_data_params = T
 
         self.predict = self.conditional_expected_number_of_purchases_up_to_time
         return self
+
+    def generate_new_data(self, size=1):
+        T = self.generate_new_data_params
+        return beta_geometric_nbd_model(
+            T, *self._unload_params('r', 'alpha0', 'a0', 'b0'), size=size)
 
     @staticmethod
     def _negative_log_likelihood(

--- a/btyd/fitters/beta_geo_fitter.py
+++ b/btyd/fitters/beta_geo_fitter.py
@@ -148,9 +148,7 @@ class BetaGeoFitter(BaseFitter):
 
         self.data = pd.DataFrame({"frequency": frequency, "recency": recency, "T": T, "weights": weights}, index=index)
 
-        self.generate_new_data = lambda size=1: beta_geometric_nbd_model(
-            T, *self._unload_params("r", "alpha", "a", "b"), size=size
-        )
+        self.generate_new_data_params = T
 
         self.predict = self.conditional_expected_number_of_purchases_up_to_time
 
@@ -159,6 +157,12 @@ class BetaGeoFitter(BaseFitter):
         self.confidence_intervals_ = self._compute_confidence_intervals()
 
         return self
+
+    def generate_new_data(self, size=1):
+        T = self.generate_new_data_params
+        return beta_geometric_nbd_model(
+            T, *self._unload_params("r", "alpha", "a", "b"), size=size
+        )
 
     @staticmethod
     def _negative_log_likelihood(

--- a/btyd/fitters/modified_beta_geo_fitter.py
+++ b/btyd/fitters/modified_beta_geo_fitter.py
@@ -103,14 +103,18 @@ class ModifiedBetaGeoFitter(BetaGeoFitter):
             frequency, recency, T, weights, initial_params, verbose, tol, index=index, **kwargs
         )
         # this needs to be reassigned from the parent method
-        self.generate_new_data = lambda size=1: modified_beta_geometric_nbd_model(
-            T, *self._unload_params("r", "alpha", "a", "b"), size=size
-        )
+        self.generate_new_data_params = T
 
         self.variance_matrix_ = self._compute_variance_matrix()
         self.standard_errors_ = self._compute_standard_errors()
         self.confidence_intervals_ = self._compute_confidence_intervals()
         return self
+
+    def generate_new_data(self, size=1):
+        T = self.generate_new_data_params
+        return modified_beta_geometric_nbd_model(
+            T, *self._unload_params("r", "alpha", "a", "b"), size=size
+        )
 
     @staticmethod
     def _negative_log_likelihood(log_params, freq, rec, T, weights, penalizer_coef):

--- a/btyd/fitters/pareto_nbd_fitter.py
+++ b/btyd/fitters/pareto_nbd_fitter.py
@@ -147,13 +147,17 @@ class ParetoNBDFitter(BaseFitter):
         self.params_["beta"] /= self._scale
 
         self.data = DataFrame({"frequency": frequency, "recency": recency, "T": T, "weights": weights}, index=index)
-        self.generate_new_data = lambda size=1: pareto_nbd_model(
-            T, *self._unload_params("r", "alpha", "s", "beta"), size=size
-        )
+        self.generate_new_data_params = T
 
         self.predict = self.conditional_expected_number_of_purchases_up_to_time
 
         return self
+
+    def generate_new_data(self, size=1):
+        T = self.generate_new_data_params
+        return pareto_nbd_model(
+            T, *self._unload_params("r", "alpha", "s", "beta"), size=size
+        )
 
     @staticmethod
     def _log_A_0(

--- a/btyd/utils.py
+++ b/btyd/utils.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import autograd.numpy as np
 import pandas as pd
-import dill
+import pickle
 
 import numpy
 import numpy.typing as npt
@@ -674,7 +674,7 @@ def _save_obj_without_attr(
             setattr(obj, attr, val_save)
 
     with open(path, "wb") as out_file:
-        dill.dump(obj, out_file)
+        pickle.dump(obj, out_file)
 
     for attr, item in saved_attr_dict.items():
         setattr(obj, attr, item)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ python = ">=3.8,<3.10"
 numpy = "^1.20.0"
 pymc = "^4.0.0"
 autograd = "1.4"
-dill = "0.3.5.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -829,32 +829,6 @@ class TestBetaGeoFitter:
         # remove saved model
         os.remove(PATH_SAVE_BGNBD_MODEL)
 
-    def test_save_load_no_generate_data(self, cdnow):
-        """Test saving and loading model for BG/NBD without generate_new_data method."""
-        bgf = lt.BetaGeoFitter(penalizer_coef=0.0)
-        bgf.fit(cdnow["frequency"], cdnow["recency"], cdnow["T"])
-        bgf.save_model(PATH_SAVE_BGNBD_MODEL, save_generate_data_method=False)
-
-        bgf_new = lt.BetaGeoFitter()
-        bgf_new.load_model(PATH_SAVE_BGNBD_MODEL)
-        assert bgf_new.__dict__["penalizer_coef"] == bgf.__dict__["penalizer_coef"]
-        assert bgf_new.__dict__["_scale"] == bgf.__dict__["_scale"]
-        assert bgf_new.__dict__["params_"].equals(bgf.__dict__["params_"])
-        assert (
-            bgf_new.__dict__["_negative_log_likelihood_"]
-            == bgf.__dict__["_negative_log_likelihood_"]
-        )
-        assert bgf_new.__dict__["predict"](1, 1, 2, 5) == bgf.__dict__["predict"](
-            1, 1, 2, 5
-        )
-        assert bgf_new.expected_number_of_purchases_up_to_time(
-            1
-        ) == bgf.expected_number_of_purchases_up_to_time(1)
-
-        assert bgf_new.__dict__["generate_new_data"] is None
-        # remove saved model
-        os.remove(PATH_SAVE_BGNBD_MODEL)
-
     def test_save_load_no_data_replace_with_empty_str(self, cdnow):
         """Test saving and loading model for BG/NBD without data with replaced value empty str."""
         bgf = lt.BetaGeoFitter(penalizer_coef=0.0)
@@ -1326,9 +1300,7 @@ class TestBetaGeoCovarsFitter:
         X_tr = np.ones((cdnow.shape[0], 1))
         X_do = np.ones((cdnow.shape[0], 1))
         bgcf.fit(cdnow["frequency"], cdnow["recency"], cdnow["T"], X_tr, X_do)
-        bgcf.save_model(
-            PATH_SAVE_BGNBD_MODEL, save_data=False, save_generate_data_method=False
-        )
+        bgcf.save_model(PATH_SAVE_BGNBD_MODEL, save_data=False)
 
         bgcf_new = lt.BetaGeoCovarsFitter()
         bgcf_new.load_model(PATH_SAVE_BGNBD_MODEL)
@@ -1346,7 +1318,6 @@ class TestBetaGeoCovarsFitter:
             1, 1, 1
         ) == bgcf.expected_number_of_purchases_up_to_time(1, 1, 1)
         assert bgcf_new.__dict__["data"] is None
-        assert bgcf_new.__dict__["generate_new_data"] is None
         # remove saved model
         os.remove(PATH_SAVE_BGNBD_MODEL)
 


### PR DESCRIPTION
Implements #63 by removing the need to serialize a lambda function and instead serializes the arguments the lambda function would need if it was called.