### PR TITLE
Model Persistence Validations

### DIFF
--- a/btyd/models/__init__.py
+++ b/btyd/models/__init__.py
@@ -154,7 +154,7 @@ class BaseModel(ABC, Generic[SELF]):
 
     def save_json(self, filename: str) -> None:
         """
-        Dump InferenceData from fitted model into a JSON or CSV file. Format is inferred from the filename.
+        Dump InferenceData from fitted model into a JSON file.
 
         Parameters
         ----------
@@ -169,7 +169,7 @@ class BaseModel(ABC, Generic[SELF]):
 
     def load_json(self, filename: str) -> SELF:
         """
-        Load InferenceData from an external file. As of 0.1beta1 only JSON files are supported.
+        Load InferenceData from an external file.
 
         Parameters
         ----------
@@ -187,7 +187,8 @@ class BaseModel(ABC, Generic[SELF]):
         else:
             self._idata = az.from_json(filename)
 
-            if dict(filter(lambda item: self.__class__.__name__ not in item[0], self._idata.get('posterior').items())):
+            # if dict(filter(lambda item: self.__class__.__name__ not in item[0], self._idata.get('posterior').items())):
+            if self.__class__.__name__ not in list(dict(self._idata.get('posterior')).keys())[0]:
                 raise NameError("Incorrect Model Type.")
             else:
                 return self

--- a/tests/test_beta_geo_model.py
+++ b/tests/test_beta_geo_model.py
@@ -321,7 +321,7 @@ class TestBetaGeoModel:
 
         assert actual_cols == expected_cols
 
-    def test_save(self, fitted_bgm):
+    def test_save_json(self, fitted_bgm):
         """
         GIVEN a fitted BetaGeoModel object,
         WHEN self.save_model() is called,
@@ -336,10 +336,10 @@ class TestBetaGeoModel:
         finally:
             assert os.path.isfile("bgnbd.json") == False
 
-            fitted_bgm.save("bgnbd.json")
+            fitted_bgm.save_json("bgnbd.json")
             assert os.path.isfile("bgnbd.json") == True
 
-    def test_load(self, fitted_bgm):
+    def test_load_json(self, fitted_bgm):
         """
         GIVEN fitted and unfitted BetaGeoModel objects,
         WHEN parameters of the fitted model are loaded from an external JSON and CSV via self.load_model(),
@@ -347,7 +347,7 @@ class TestBetaGeoModel:
         """
 
         bgm_new = btyd.BetaGeoModel()
-        bgm_new.load("bgnbd.json")
+        bgm_new.load_json("bgnbd.json")
         assert isinstance(bgm_new._idata, az.InferenceData)
         # assert bgm_new._idata.posterior.keys() ==  'sample'
         assert bgm_new._unload_params() == fitted_bgm._unload_params()

--- a/tests/test_beta_geo_model.py
+++ b/tests/test_beta_geo_model.py
@@ -324,8 +324,8 @@ class TestBetaGeoModel:
     def test_save_json(self, fitted_bgm):
         """
         GIVEN a fitted BetaGeoModel object,
-        WHEN self.save_model() is called,
-        THEN the external JSON and CSV files should exist.
+        WHEN self.save_json() is called,
+        THEN the external JSON files should exist.
         """
 
         # Remove saved file if it already exists:
@@ -342,7 +342,7 @@ class TestBetaGeoModel:
     def test_load_json(self, fitted_bgm):
         """
         GIVEN fitted and unfitted BetaGeoModel objects,
-        WHEN parameters of the fitted model are loaded from an external JSON and CSV via self.load_model(),
+        WHEN parameters of the fitted model are loaded from an external JSON via self.load_json(),
         THEN InferenceData unloaded parameters should match, raising exceptions otherwise and if predictions attempted without RFM data.
         """
 

--- a/tests/test_gamma_gamma_model.py
+++ b/tests/test_gamma_gamma_model.py
@@ -256,10 +256,10 @@ class TestGammaGammaModel:
         assert isinstance(array_out, instance)
         assert len(array_out) == draws
 
-    def test_save(self, fitted_ggm):
+    def test_save_json(self, fitted_ggm):
         """
         GIVEN a fitted GammaGammaModel object,
-        WHEN self.save_model() is called,
+        WHEN self.save_json() is called,
         THEN the external JSON file should exist.
         """
 
@@ -271,18 +271,18 @@ class TestGammaGammaModel:
         finally:
             assert os.path.isfile("ggm.json") == False
 
-            fitted_ggm.save("ggm.json")
+            fitted_ggm.save_json("ggm.json")
             assert os.path.isfile("ggm.json") == True
 
-    def test_load(self, fitted_ggm):
+    def test_load_json(self, fitted_ggm):
         """
         GIVEN fitted and unfitted GammaGammaModel objects,
-        WHEN parameters of the fitted model are loaded from an external JSON  via self.load_model(),
+        WHEN parameters of the fitted model are loaded from an external JSON  via self.load_json(),
         THEN InferenceData unloaded parameters should match, raising exceptions otherwise and if predictions attempted without RFM data.
         """
 
         ggm_new = btyd.GammaGammaModel()
-        ggm_new.load("ggm.json")
+        ggm_new.load_json("ggm.json")
         assert isinstance(ggm_new._idata, az.InferenceData)
         # assert ggm_new._idata.posterior.keys() ==  'sample'
         assert ggm_new._unload_params() == fitted_ggm._unload_params()


### PR DESCRIPTION
This PR removes CSV model persistence (which was never fully functional to begin with) and adds a  __class__.__name__ validation check to ensure the correct model JSON file is being loaded into an instantiated model class. It also adds a __class__.__name__ check to `_dataframe_parser`, so that method is no longer static. Since this same check was removed from `_check_inputs`, that method is static now and will be moved to `utils.py` in a future release as it would be useful for some of the other functions in that module.

Tests are currently failing for `mod_beta_geo_model.py`, but I'll have a merge conflict if that file is modified. This will be rectified in the final PR for v0.1b3.